### PR TITLE
シーン切り替え中にプレイヤーが’動く

### DIFF
--- a/Assets/Scenes/Fight.unity
+++ b/Assets/Scenes/Fight.unity
@@ -302,15 +302,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isAlive: 0
   health: 10
-  _attackPrefabs:
-  - {fileID: 2271366039845924913, guid: 7ae10fbf9f039cb498f3eb33fe4e5099, type: 3}
-  - {fileID: 8056262493575415640, guid: d77e73267df637446b9037d94f2ae776, type: 3}
-  - {fileID: 665740549187784687, guid: e61ab85f408f527479cefcc38fa4839d, type: 3}
+  _hand: {fileID: 0}
+  _knife: {fileID: 0}
+  _pot: {fileID: 0}
+  _setHand: 1
+  _setKnife: 1
+  _setPot: 1
   _player: {fileID: 2106303190}
   _attackStartHeight: 4
   _stageHeight: 0
-  _stageLimit_x: 30
-  _stageLimit_z: 30
+  _stageLimit_top_left: {fileID: 0}
+  _stageLimit_bottom_right: {fileID: 0}
 --- !u!4 &33792268
 Transform:
   m_ObjectHideFlags: 0
@@ -530,6 +532,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 253a462db8c164e3794cde55d36ea1b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _core: {fileID: 0}
 --- !u!4 &751812662
 Transform:
   m_ObjectHideFlags: 0
@@ -682,6 +685,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 764192eda4a1d42c3921dc79afebddb6, type: 3}
+--- !u!114 &1489252942 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6701200829780284100, guid: 74705e37bed2b4542b2fdb448db3d0b3, type: 3}
+  m_PrefabInstance: {fileID: 2106303189}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1549009609
 GameObject:
   m_ObjectHideFlags: 0
@@ -1100,8 +1114,32 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _input
+      value: 
+      objectReference: {fileID: 1489252942}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
       propertyPath: gameState
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _move.m_Name
+      value: Move
+      objectReference: {fileID: 0}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _action.m_Name
+      value: Action
+      objectReference: {fileID: 0}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _action.m_SingletonActionBindings.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _action.m_SingletonActionBindings.Array.data[0].m_Id
+      value: dd9ea100-d872-4815-8309-a669a914dba7
+      objectReference: {fileID: 0}
+    - target: {fileID: 348265188698559393, guid: d3a35c132e896487eaee6369faa12165, type: 3}
+      propertyPath: _action.m_SingletonActionBindings.Array.data[0].m_Action
+      value: Action
       objectReference: {fileID: 0}
     - target: {fileID: 1375568432692862430, guid: d3a35c132e896487eaee6369faa12165, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Fight/FightManager.cs
+++ b/Assets/Scripts/Fight/FightManager.cs
@@ -20,5 +20,6 @@ public class FightManager : MonoBehaviour
     {
         MainGameManager.instance.isClear = isClear;
         SceneFadeManager.instance.FadeOut("Result");
+        
     }
 }

--- a/Assets/Scripts/GameManagers/MainGameManager.cs
+++ b/Assets/Scripts/GameManagers/MainGameManager.cs
@@ -116,6 +116,8 @@ public class MainGameManager : MonoBehaviour
         {
             SceneManager.LoadScene(sceneName);
         }
+
+
     }
 
     void Reset()

--- a/Assets/Scripts/GameManagers/SceneFadeManager.cs
+++ b/Assets/Scripts/GameManagers/SceneFadeManager.cs
@@ -6,8 +6,8 @@ using UnityEngine.UI;
 
 public class SceneFadeManager : MonoBehaviour
 {
-    bool isFadeIn;
-    bool isFadeOut;
+   public bool isFadeIn { private set;  get; }
+   public bool isFadeOut { private set; get; }
 
     [SerializeField]
     private Image fadeImage;
@@ -20,6 +20,8 @@ public class SceneFadeManager : MonoBehaviour
     public static SceneFadeManager instance;
 
     private string afterScene;
+
+    
 
     void Awake()
     {
@@ -52,12 +54,12 @@ public class SceneFadeManager : MonoBehaviour
     }
 
     /**
-     * @brief ƒtƒF[ƒhƒAƒEƒg‚µ‚ÄAŸ‚ÌƒV[ƒ“‚É‘JˆÚ‚·‚é
-     * @param nextScene ‘JˆÚæ‚ÌƒV[ƒ“–¼
+     * @brief ãƒ•ã‚§ãƒ¼ãƒ‰ã‚¢ã‚¦ãƒˆã—ã¦ã€æ¬¡ã®ã‚·ãƒ¼ãƒ³ã«é·ç§»ã™ã‚‹
+     * @param nextScene é·ç§»å…ˆã®ã‚·ãƒ¼ãƒ³å
      */
     public void FadeOut(string nextScene)
     {
-        // ƒtƒF[ƒhƒAƒEƒg‚Ìƒtƒ‰ƒO‚ğã‚°‚é
+        // ãƒ•ã‚§ãƒ¼ãƒ‰ã‚¢ã‚¦ãƒˆã®ãƒ•ãƒ©ã‚°ã‚’ä¸Šã’ã‚‹
         isFadeOut = true;
 
         afterScene = nextScene;

--- a/Assets/Scripts/Players/PlayerCore.cs
+++ b/Assets/Scripts/Players/PlayerCore.cs
@@ -44,8 +44,6 @@ namespace Players
 
         [SerializeField][Tooltip("減少量")] private float decreaseUnionCount;
 
-
-
         void Awake()
         {
             _inputs = GetComponent<PlayerInputs>();
@@ -77,6 +75,7 @@ namespace Players
 
         private void FixedUpdate()
         {
+            if (SceneFadeManager.instance.isFadeIn || SceneFadeManager.instance.isFadeOut) return;
             Move();
         }
 
@@ -195,5 +194,6 @@ namespace Players
         {
             return _currentParameters.health;
         }
+
     }
 }


### PR DESCRIPTION
change:
SceneFadeManager.isFadeIn,isFadeOutを読み取り用に編集
PlayerCoreに条件を追加

フェードイン、フェードアウト中にプレイヤーの操作を受け付けないようにしました。
FightシーンからResultシーンへの遷移で動作確認済みです。